### PR TITLE
Improve debugging of HTTP layer

### DIFF
--- a/java/hiro-client/src/main/java/co/arago/hiro/client/auth/AbstractTokenProvider.java
+++ b/java/hiro-client/src/main/java/co/arago/hiro/client/auth/AbstractTokenProvider.java
@@ -82,9 +82,7 @@ public abstract class AbstractTokenProvider implements TokenProvider, Closeable 
     final BoundRequestBuilder builder = newRequest(data, fullApiUrl());
 
     try {
-      if (LOG.isLoggable(Level.FINEST)) {
-        HttpClientHelper.debugRequest(builder.build(), LOG, Level.FINEST);
-      }
+      HttpClientHelper.debugRequest(builder.build(), LOG, Level.FINEST);
 
       final Response response = checkResponse(builder.execute().get(timeout, TimeUnit.MILLISECONDS));
 
@@ -130,9 +128,7 @@ public abstract class AbstractTokenProvider implements TokenProvider, Closeable 
 
     Response response;
     try {
-      if (LOG.isLoggable(Level.FINEST)) {
-        HttpClientHelper.debugRequest(builder.build(), LOG, Level.FINEST);
-      }
+      HttpClientHelper.debugRequest(builder.build(), LOG, Level.FINEST);
 
       response = checkResponse(builder.execute().get(timeout, TimeUnit.MILLISECONDS));
       if (resetState) {
@@ -177,9 +173,7 @@ public abstract class AbstractTokenProvider implements TokenProvider, Closeable 
   }
 
   private Response checkResponse(final Response response) {
-    if (LOG.isLoggable(Level.FINEST)) {
-      HttpClientHelper.debugResponse(response, LOG, Level.FINEST);
-    }
+    HttpClientHelper.debugResponse(response, LOG, Level.FINEST);
 
     if (response.getStatusCode() != 200) {
       if (response.getStatusCode() == 400 || response.getStatusCode() == 403) {

--- a/java/hiro-client/src/main/java/co/arago/hiro/client/rest/AuthenticatedRestClient.java
+++ b/java/hiro-client/src/main/java/co/arago/hiro/client/rest/AuthenticatedRestClient.java
@@ -211,9 +211,7 @@ public class AuthenticatedRestClient implements RestClient {
     addToken(prepareGet);
 
     try {
-      if (LOG.isLoggable(Level.FINEST)) {
-        HttpClientHelper.debugRequest(prepareGet.build(), LOG, Level.FINEST);
-      }
+      HttpClientHelper.debugRequest(prepareGet.build(), LOG, Level.FINEST);
       final Response r = prepareGet.execute().get(timeout, TimeUnit.MILLISECONDS);
       if (tokenProvider.checkTokenRenewal(r)) {
         tokenProvider.renewToken();
@@ -307,9 +305,7 @@ public class AuthenticatedRestClient implements RestClient {
       addDefaultHeaders(builder, parameters);
       addParameters(builder, parameters);
 
-      if (LOG.isLoggable(Level.FINEST)) {
-        HttpClientHelper.debugRequest(builder.build(), LOG, Level.FINEST);
-      }
+      HttpClientHelper.debugRequest(builder.build(), LOG, Level.FINEST);
 
       ListenableFuture<Response> execute = builder.execute(new AsyncHandler<Response>() {
         private final Response.ResponseBuilder builder = new Response.ResponseBuilder();
@@ -374,15 +370,11 @@ public class AuthenticatedRestClient implements RestClient {
       addParameters(builder, parameters);
       addBody(builder, json);
 
-      if (LOG.isLoggable(Level.FINEST)) {
-        HttpClientHelper.debugRequest(builder.build(), LOG, Level.FINEST);
-      }
+      HttpClientHelper.debugRequest(builder.build(), LOG, Level.FINEST);
 
       // having a timeout is good practice, even if it is one week
       Response response = builder.execute().get(timeout, TimeUnit.MILLISECONDS);
-      if (LOG.isLoggable(Level.FINEST)) {
-        HttpClientHelper.debugResponse(response, LOG, Level.FINEST);
-      }
+      HttpClientHelper.debugResponse(response, LOG, Level.FINEST);
       return checkResponse(response);
     } catch (Throwable t) {
       return Throwables.unchecked(t);

--- a/java/hiro-client/src/main/java/co/arago/hiro/client/util/HttpClientHelper.java
+++ b/java/hiro-client/src/main/java/co/arago/hiro/client/util/HttpClientHelper.java
@@ -17,6 +17,7 @@ import org.asynchttpclient.Response;
 public final class HttpClientHelper
 {
   private static final String USERAGENT = "co.arago.hiro.client/" + VersionHelper.version();
+  public static Level HTTP_DEBUG_LEVEL = Level.FINEST;
 
   private static AsyncHttpClient _newClient(boolean trustAllCerts, int timeout) {
     final DefaultAsyncHttpClientConfig.Builder builder = new DefaultAsyncHttpClientConfig.Builder();
@@ -97,7 +98,7 @@ public final class HttpClientHelper
       sb.append("  Body=[");
       sb.append(req.getStringData());
       sb.append("]\n]");
-      logger.log(level, sb.toString());
+      logger.log(HTTP_DEBUG_LEVEL, sb.toString());
     }
   }
 
@@ -127,7 +128,7 @@ public final class HttpClientHelper
         sb.append("]\n");
       }
       sb.append("]");
-      logger.log(level, sb.toString());
+      logger.log(HTTP_DEBUG_LEVEL, sb.toString());
     }
   }
 


### PR DESCRIPTION
* final log will be done with a fixed level (Level.FINEST)
  this allows clients to override this to ensure that
  console logger shows the message (by setting Level.INFO)
* remove some redundant level checks