### PR TITLE
Fixed wrong api path

### DIFF
--- a/java/hiro-client/src/main/java/co/arago/hiro/client/rest/DefaultHiroClient.java
+++ b/java/hiro-client/src/main/java/co/arago/hiro/client/rest/DefaultHiroClient.java
@@ -70,7 +70,7 @@ public class DefaultHiroClient implements HiroClient {
             boolean trustAllCerts, Level debugLevel, int timeout, String apiVersion) {
         String apiPath;
         if (apiVersion != null && !apiVersion.isEmpty()) {
-            apiPath = StringUtils.join(HiroCollections.newList(API_PREFIX, apiVersion, API_SUFFIX), URL_SEPARATOR);
+            apiPath = StringUtils.join(HiroCollections.newList(API_PREFIX, API_SUFFIX, apiVersion), URL_SEPARATOR);
         } else if (apiVersion != null && apiVersion.isEmpty()) {
             apiPath = "";// 6.0 graph
         } else {


### PR DESCRIPTION
When api version set by setApiVersion() client create wrong api path
For example
1) right variant - /api/graph/7.1
2) variant which client create  with using setApiVersion()  - /api/7.1/path