### PR TITLE
Debugged autoreconnect and added automatic handling of eventFilters.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 target/
 _hiro.version
+*.iml

--- a/java/hiro-action-client/pom.xml
+++ b/java/hiro-action-client/pom.xml
@@ -4,11 +4,11 @@
   <groupId>co.arago</groupId>
   <artifactId>hiro-action-client</artifactId>
   <name>${project.artifactId}</name>
-  <version>2.1.4-SNAPSHOT</version>
+  <version>2.1.5-SNAPSHOT</version>
   <parent>
     <groupId>co.arago</groupId>
     <artifactId>hiro-client-all</artifactId>
-    <version>2.1.4-SNAPSHOT</version>
+    <version>2.1.5-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/java/hiro-client/pom-open.xml
+++ b/java/hiro-client/pom-open.xml
@@ -4,7 +4,7 @@
   <groupId>co.arago</groupId>
   <artifactId>hiro-client</artifactId>
   <name>${project.artifactId}</name>
-  <version>2.1.4-SNAPSHOT</version>
+  <version>2.1.5-SNAPSHOT</version>
 
   <properties>
     <maven.exec.skip>false</maven.exec.skip>

--- a/java/hiro-client/pom.xml
+++ b/java/hiro-client/pom.xml
@@ -4,11 +4,11 @@
   <groupId>co.arago</groupId>
   <artifactId>hiro-client</artifactId>
   <name>${project.artifactId}</name>
-  <version>2.1.4-SNAPSHOT</version>
+  <version>2.1.5-SNAPSHOT</version>
   <parent>
     <groupId>co.arago</groupId>
     <artifactId>hiro-client-all</artifactId>
-    <version>2.1.4-SNAPSHOT</version>
+    <version>2.1.5-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/java/hiro-client/src/main/java/co/arago/hiro/client/api/HiroClient.java
+++ b/java/hiro-client/src/main/java/co/arago/hiro/client/api/HiroClient.java
@@ -1,6 +1,7 @@
 package co.arago.hiro.client.api;
 
 import co.arago.hiro.client.util.Listener;
+
 import java.io.Closeable;
 import java.io.InputStream;
 import java.util.List;

--- a/java/hiro-client/src/main/java/co/arago/hiro/client/api/RestClient.java
+++ b/java/hiro-client/src/main/java/co/arago/hiro/client/api/RestClient.java
@@ -1,6 +1,7 @@
 package co.arago.hiro.client.api;
 
 import co.arago.hiro.client.util.Listener;
+
 import java.io.Closeable;
 import java.io.InputStream;
 import java.nio.charset.Charset;

--- a/java/hiro-client/src/main/java/co/arago/hiro/client/api/TokenProvider.java
+++ b/java/hiro-client/src/main/java/co/arago/hiro/client/api/TokenProvider.java
@@ -1,7 +1,8 @@
 package co.arago.hiro.client.api;
 
-import java.io.Closeable;
 import org.asynchttpclient.Response;
+
+import java.io.Closeable;
 
 /**
  *

--- a/java/hiro-client/src/main/java/co/arago/hiro/client/api/WebSocketClient.java
+++ b/java/hiro-client/src/main/java/co/arago/hiro/client/api/WebSocketClient.java
@@ -15,4 +15,8 @@ public interface WebSocketClient extends Closeable {
     long sendMessage(String type, Map<String, String> headers, Map body);
 
     void sendMessage(String message);
+
+    void addEventFilter(Map filter);
+    void removeEventFilter(String id);
+    void clearEventFilters();
 }

--- a/java/hiro-client/src/main/java/co/arago/hiro/client/auth/AbstractTokenProvider.java
+++ b/java/hiro-client/src/main/java/co/arago/hiro/client/auth/AbstractTokenProvider.java
@@ -6,6 +6,12 @@ import co.arago.hiro.client.util.HiroCollections;
 import co.arago.hiro.client.util.HiroException;
 import co.arago.hiro.client.util.HttpClientHelper;
 import co.arago.hiro.client.util.Throwables;
+import net.minidev.json.JSONValue;
+import org.apache.commons.lang.StringUtils;
+import org.asynchttpclient.AsyncHttpClient;
+import org.asynchttpclient.BoundRequestBuilder;
+import org.asynchttpclient.Response;
+
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.HashMap;
@@ -13,13 +19,8 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import net.minidev.json.JSONValue;
-import org.apache.commons.lang.StringUtils;
-import org.asynchttpclient.AsyncHttpClient;
-import org.asynchttpclient.BoundRequestBuilder;
-import org.asynchttpclient.Response;
 
-import static co.arago.hiro.client.util.Helper.*;
+import static co.arago.hiro.client.util.Helper.notEmpty;
 
 /**
  *

--- a/java/hiro-client/src/main/java/co/arago/hiro/client/auth/DeviceTokenProvider.java
+++ b/java/hiro-client/src/main/java/co/arago/hiro/client/auth/DeviceTokenProvider.java
@@ -1,10 +1,11 @@
 package co.arago.hiro.client.auth;
 
-import java.util.Map;
-import java.util.logging.Level;
 import org.asynchttpclient.AsyncHttpClient;
 
-import static co.arago.hiro.client.util.Helper.*;
+import java.util.Map;
+import java.util.logging.Level;
+
+import static co.arago.hiro.client.util.Helper.notEmpty;
 
 /**
  *

--- a/java/hiro-client/src/main/java/co/arago/hiro/client/auth/FixedTokenProvider.java
+++ b/java/hiro-client/src/main/java/co/arago/hiro/client/auth/FixedTokenProvider.java
@@ -1,10 +1,11 @@
 package co.arago.hiro.client.auth;
 
 import co.arago.hiro.client.api.TokenProvider;
+import org.asynchttpclient.Response;
+
 import java.io.IOException;
 
 import static co.arago.hiro.client.util.Helper.notEmpty;
-import org.asynchttpclient.Response;
 
 /**
  *

--- a/java/hiro-client/src/main/java/co/arago/hiro/client/auth/PasswordTokenProvider.java
+++ b/java/hiro-client/src/main/java/co/arago/hiro/client/auth/PasswordTokenProvider.java
@@ -1,8 +1,9 @@
 package co.arago.hiro.client.auth;
 
+import org.asynchttpclient.AsyncHttpClient;
+
 import java.util.Map;
 import java.util.logging.Level;
-import org.asynchttpclient.AsyncHttpClient;
 
 import static co.arago.hiro.client.util.Helper.notEmpty;
 

--- a/java/hiro-client/src/main/java/co/arago/hiro/client/auth/legacy/AbstractTokenProvider.java
+++ b/java/hiro-client/src/main/java/co/arago/hiro/client/auth/legacy/AbstractTokenProvider.java
@@ -1,20 +1,22 @@
 package co.arago.hiro.client.auth.legacy;
 
 import co.arago.hiro.client.api.TokenProvider;
-import static co.arago.hiro.client.util.Helper.notEmpty;
 import co.arago.hiro.client.util.HiroException;
 import co.arago.hiro.client.util.HttpClientHelper;
 import co.arago.hiro.client.util.Throwables;
+import net.minidev.json.JSONValue;
+import org.asynchttpclient.AsyncHttpClient;
+import org.asynchttpclient.BoundRequestBuilder;
+import org.asynchttpclient.Response;
+
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import net.minidev.json.JSONValue;
-import org.asynchttpclient.AsyncHttpClient;
-import org.asynchttpclient.BoundRequestBuilder;
-import org.asynchttpclient.Response;
+
+import static co.arago.hiro.client.util.Helper.notEmpty;
 
 /**
  *

--- a/java/hiro-client/src/main/java/co/arago/hiro/client/auth/legacy/PasswordTokenProvider.java
+++ b/java/hiro-client/src/main/java/co/arago/hiro/client/auth/legacy/PasswordTokenProvider.java
@@ -1,10 +1,12 @@
 package co.arago.hiro.client.auth.legacy;
 
-import java.util.logging.Level;
 import org.asynchttpclient.AsyncHttpClient;
 import org.asynchttpclient.BoundRequestBuilder;
-import static co.arago.hiro.client.util.Helper.notEmpty;
 import org.asynchttpclient.Response;
+
+import java.util.logging.Level;
+
+import static co.arago.hiro.client.util.Helper.notEmpty;
 
 /**
  *

--- a/java/hiro-client/src/main/java/co/arago/hiro/client/builder/TokenBuilder.java
+++ b/java/hiro-client/src/main/java/co/arago/hiro/client/builder/TokenBuilder.java
@@ -6,10 +6,10 @@ import co.arago.hiro.client.auth.FixedTokenProvider;
 import co.arago.hiro.client.auth.PasswordTokenProvider;
 import org.asynchttpclient.AsyncHttpClient;
 
-import static co.arago.hiro.client.util.Helper.notEmpty;
 import java.util.logging.Level;
 
 import static co.arago.hiro.client.auth.AbstractTokenProvider.DEFAULT_API_VERSION;
+import static co.arago.hiro.client.util.Helper.notEmpty;
 
 /**
  *

--- a/java/hiro-client/src/main/java/co/arago/hiro/client/rest/DefaultHiroClient.java
+++ b/java/hiro-client/src/main/java/co/arago/hiro/client/rest/DefaultHiroClient.java
@@ -1,18 +1,12 @@
 package co.arago.hiro.client.rest;
 
-import co.arago.hiro.client.api.HiroClient;
-import co.arago.hiro.client.api.LogValue;
-import co.arago.hiro.client.api.TimeseriesValue;
-import co.arago.hiro.client.api.TokenProvider;
-import co.arago.hiro.client.api.WebSocketClient;
+import co.arago.hiro.client.api.*;
 import co.arago.hiro.client.builder.ClientBuilder;
-import co.arago.hiro.client.util.DefaultLogValue;
-import co.arago.hiro.client.util.DefaultTimeseriesValue;
-import co.arago.hiro.client.util.Helper;
-import co.arago.hiro.client.util.HiroCollections;
-import co.arago.hiro.client.util.Listener;
-import co.arago.hiro.client.util.SimpleWsListener;
-import co.arago.hiro.client.util.Throwables;
+import co.arago.hiro.client.util.*;
+import net.minidev.json.JSONValue;
+import org.apache.commons.lang.StringUtils;
+import org.asynchttpclient.AsyncHttpClient;
+import org.asynchttpclient.Response;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -20,18 +14,14 @@ import java.net.URLEncoder;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ExecutionException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import net.minidev.json.JSONValue;
-import org.apache.commons.lang.StringUtils;
-import org.asynchttpclient.AsyncHttpClient;
 
-import static co.arago.hiro.client.util.Helper.*;
-import static co.arago.hiro.client.api.RestClient.*;
-import co.arago.hiro.client.util.HiroException;
-import co.arago.hiro.client.util.HttpClientHelper;
-import java.util.concurrent.ExecutionException;
-import org.asynchttpclient.Response;
+import static co.arago.hiro.client.api.RestClient.DEFAULT_ENCODING;
+import static co.arago.hiro.client.api.RestClient.HEADER_CONTENT_TYPE;
+import static co.arago.hiro.client.util.Helper.notEmpty;
+import static co.arago.hiro.client.util.Helper.notNull;
 
 public class DefaultHiroClient implements HiroClient {
 

--- a/java/hiro-client/src/main/java/co/arago/hiro/client/rest/DefaultWebSocketClient.java
+++ b/java/hiro-client/src/main/java/co/arago/hiro/client/rest/DefaultWebSocketClient.java
@@ -3,16 +3,23 @@ package co.arago.hiro.client.rest;
 import co.arago.hiro.client.api.TokenProvider;
 import co.arago.hiro.client.api.WebSocketClient;
 import co.arago.hiro.client.builder.ClientBuilder.WebsocketType;
-import co.arago.hiro.client.util.Helper;
-import co.arago.hiro.client.util.HiroCollections;
-import co.arago.hiro.client.util.HiroException;
-import co.arago.hiro.client.util.Listener;
-import co.arago.hiro.client.util.Throwables;
+import co.arago.hiro.client.util.*;
+import net.minidev.json.JSONValue;
+import org.apache.commons.lang.StringUtils;
+import org.asynchttpclient.AsyncHttpClient;
+import org.asynchttpclient.ws.WebSocket;
+import org.asynchttpclient.ws.WebSocketListener;
+import org.asynchttpclient.ws.WebSocketUpgradeHandler;
+
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.time.Duration;
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Random;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -20,11 +27,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import net.minidev.json.JSONValue;
-import org.asynchttpclient.AsyncHttpClient;
-import org.asynchttpclient.ws.WebSocket;
-import org.asynchttpclient.ws.WebSocketListener;
-import org.asynchttpclient.ws.WebSocketUpgradeHandler;
 
 public final class DefaultWebSocketClient implements WebSocketClient {
     private static final long PING_TIMEOUT = 30 * 1000;
@@ -40,18 +42,139 @@ public final class DefaultWebSocketClient implements WebSocketClient {
     private int retries = 0;
     private final AtomicLong idCounter = new AtomicLong();
     private final String restApiUrl;
-    private final Listener<String> loglistener;
+    private final Listener<String> logListener;
     private final Listener<String> dataListener;
-    private final AsyncHttpClient client;
+    private AsyncHttpClient client;
     private final TokenProvider tokenProvider;
     private final int timeout;
     private final WebsocketType type;
     private final String urlParameters;
     private final WebSocketListener handler;
 
+    private final Map<String, Map> eventFilterMessages = new LinkedHashMap<>();
+
+    private class DefaultWebSocketListener implements WebSocketListener {
+
+        private boolean reconnect;
+
+        public DefaultWebSocketListener(boolean reconnect) {
+            this.reconnect = reconnect;
+        }
+
+        /**
+         * Invoked when the {@link WebSocket} is open.
+         *
+         * @param websocket the WebSocket
+         */
+        @Override
+        public void onOpen(WebSocket websocket) {
+            final Map m = HiroCollections.newMap();
+            m.put("type", "open");
+            m.put("open", websocket.isOpen());
+
+            if (LOG.isLoggable(Level.FINEST)) {
+                LOG.log(Level.FINEST, "connected " + this);
+            }
+
+            if (handler != null) {
+                handler.onOpen(websocket);
+            }
+
+            process(logListener, JSONValue.toJSONString(m));
+            reconnect = false;
+        }
+
+        /**
+         * Invoked when the {@link WebSocket} is closed.
+         *
+         * @param websocket the WebSocket
+         * @param code      the status code
+         * @param reason    the reason message
+         * @see "http://tools.ietf.org/html/rfc6455#section-5.5.1"
+         */
+        @Override
+        public void onClose(WebSocket websocket, int code, String reason) {
+            final Map m = HiroCollections.newMap();
+            m.put("type", "close");
+            m.put("code", code);
+            m.put("reason", reason);
+
+            if (LOG.isLoggable(Level.FINEST)) {
+                LOG.log(Level.FINEST, "received close " + this);
+            }
+
+            if (handler != null) {
+                handler.onClose(websocket, code, reason);
+            }
+
+            process(logListener, JSONValue.toJSONString(m));
+
+            if (!reconnect)
+                reconnect();
+
+        }
+
+        /**
+         * Invoked when the {@link WebSocket} crashes.
+         *
+         * @param t a {@link Throwable}
+         */
+        @Override
+        public void onError(Throwable t) {
+            final Map m = HiroCollections.newMap();
+            m.put("type", "error");
+            m.put("message", t.getMessage());
+            m.put("stack", stacktrace(t));
+
+            if (LOG.isLoggable(Level.FINEST)) {
+                LOG.log(Level.FINEST, "received error " + this, t);
+            }
+
+            if (handler != null) {
+                handler.onError(t);
+            }
+
+            process(logListener, JSONValue.toJSONString(m));
+
+            if (!reconnect)
+                reconnect();
+
+        }
+
+        @Override
+        public void onTextFrame(String payload, boolean finalFragment, int rsv) {
+            if (LOG.isLoggable(Level.FINEST)) {
+                LOG.log(Level.FINEST, "received message " + payload);
+            }
+
+            if (handler != null) {
+                handler.onTextFrame(payload, finalFragment, rsv);
+            }
+
+            Object o = JSONValue.parse(payload);
+            if (o instanceof Map && ((Map) o).containsKey("error")) {
+                Map error = (Map) ((Map) o).get("error");
+                if ((int) error.get("code") == 401) {
+                    tokenProvider.renewToken();
+                    reconnect();
+                    return;
+                }
+            }
+
+            process(dataListener, payload);
+        }
+
+        @Override
+        public void onPingFrame(byte[] payload) {
+            if (webSocketClient != null && webSocketClient.isOpen()) {
+                webSocketClient.sendPongFrame(payload);
+            }
+        }
+    }
+
     public DefaultWebSocketClient(String restApiUrl, String urlParameters, TokenProvider tokenProvider,
-            AsyncHttpClient client, Level debugLevel, int timeout, WebsocketType type, Listener<String> dataListener,
-            Listener<String> loglistener, WebSocketListener handler)
+                                  AsyncHttpClient client, Level debugLevel, int timeout, WebsocketType type, Listener<String> dataListener,
+                                  Listener<String> logListener, WebSocketListener handler, List<Map> eventFilterMessages)
             throws InterruptedException, ExecutionException, URISyntaxException {
 
         if (debugLevel != null) {
@@ -61,34 +184,28 @@ public final class DefaultWebSocketClient implements WebSocketClient {
         this.restApiUrl = restApiUrl;
         this.tokenProvider = tokenProvider;
         this.timeout = timeout <= 0 ? 5000 : timeout;
-        this.loglistener = loglistener;
+        this.logListener = logListener;
         this.dataListener = dataListener;
         this.client = client;
         this.type = type;
         this.urlParameters = urlParameters;
         this.handler = handler;
 
-        connect(false, true);
+        for (Map filter : eventFilterMessages) {
+            this.eventFilterMessages.put(getFilterId(filter), filter);
+        }
+
+        connect(false);
 
         executor.scheduleWithFixedDelay(() -> ping(), PING_TIMEOUT, PING_TIMEOUT, TimeUnit.MILLISECONDS);
     }
 
-    private void connect(boolean waitForIt, boolean initial) {
+    /**
+     * Setup the websocket and connect.
+     */
+    private void connect(boolean reconnect) {
         if (!running) {
             return;
-        }
-
-        if (!initial) {
-            closeWs();
-        }
-
-        if (waitForIt) {
-            try {
-                Thread.sleep(1000);
-            } catch (InterruptedException ex) {
-                closeWs();
-                Throwables.unchecked(ex);
-            }
         }
 
         if (LOG.isLoggable(Level.FINEST)) {
@@ -97,110 +214,27 @@ public final class DefaultWebSocketClient implements WebSocketClient {
 
         WebSocketUpgradeHandler.Builder upgradeHandlerBuilder = new WebSocketUpgradeHandler.Builder();
 
-        WebSocketUpgradeHandler wsHandler = upgradeHandlerBuilder.addWebSocketListener(new WebSocketListener() {
-            @Override
-            public void onOpen(WebSocket websocket) {
-                final Map m = HiroCollections.newMap();
-                m.put("type", "open");
-                m.put("open", websocket.isOpen());
-
-                if (LOG.isLoggable(Level.FINEST)) {
-                    LOG.log(Level.FINEST, "connected " + this);
-                }
-
-                if (handler != null) {
-                    handler.onOpen(websocket);
-                }
-
-                process(loglistener, JSONValue.toJSONString(m));
-            }
-
-            @Override
-            public void onClose(WebSocket websocket, int code, String reason) {
-                final Map m = HiroCollections.newMap();
-                m.put("type", "close");
-                m.put("code", code);
-                m.put("reason", reason);
-
-                if (LOG.isLoggable(Level.FINEST)) {
-                    LOG.log(Level.FINEST, "received close " + this);
-                }
-
-                if (handler != null) {
-                    handler.onClose(websocket, code, reason);
-                }
-
-                process(loglistener, JSONValue.toJSONString(m));
-
-                if (running && !initial) {
-                    connect(false, initial);
-                }
-            }
-
-            @Override
-            public void onError(Throwable t) {
-                final Map m = HiroCollections.newMap();
-                m.put("type", "error");
-                m.put("message", t.getMessage());
-                m.put("stack", stacktrace(t));
-
-                if (LOG.isLoggable(Level.FINEST)) {
-                    LOG.log(Level.FINEST, "received error " + this, t);
-                }
-
-                if (handler != null) {
-                    handler.onError(t);
-                }
-
-                process(loglistener, JSONValue.toJSONString(m));
-
-                if (WebsocketType.Event == type) {
-                    close();
-                    throw new HiroException("connection closed", 400);
-                }
-
-                if (running && !initial) {
-                    connect(false, initial);
-                }
-            }
-
-            @Override
-            public void onTextFrame(String payload, boolean finalFragment, int rsv) {
-                if (LOG.isLoggable(Level.FINEST)) {
-                    LOG.log(Level.FINEST, "received message " + payload);
-                }
-
-                if (handler != null) {
-                    handler.onTextFrame(payload, finalFragment, rsv);
-                }
-
-                Object o = JSONValue.parse(payload);
-                if (o instanceof Map && ((Map) o).containsKey("error")) {
-                    Map error = (Map) ((Map) o).get("error");
-                    if ((int) error.get("code") == 401) {
-                        tokenProvider.renewToken();
-                        connect(false, false);
-                        return;
-                    } else if (WebsocketType.Event == type) {
-                        throw new HiroException((String) error.get("message"), (int) error.get("code"));
-                    }
-                }
-
-                process(dataListener, payload);
-            }
-
-            @Override
-            public void onPingFrame(byte[] payload) {
-                if (webSocketClient != null && webSocketClient.isOpen()) {
-                    webSocketClient.sendPongFrame(payload);
-                }
-            }
-        }).build();
+        WebSocketUpgradeHandler wsHandler = upgradeHandlerBuilder
+                .addWebSocketListener(new DefaultWebSocketListener(reconnect))
+                .build();
 
         try {
             webSocketClient = client.prepareGet(composeWsUrl(restApiUrl))
                     .addHeader("Sec-WebSocket-Protocol", getProtocol() + ", token-" + tokenProvider.getToken())
                     .setRequestTimeout(timeout).execute(wsHandler).get(timeout, TimeUnit.MILLISECONDS);
+
+            if (webSocketClient == null) {
+                throw new HiroException("Failed to initialize WebSocketClient. It is null.", 500);
+            }
+
+            if (type == WebsocketType.Event) {
+                for (Map filter : eventFilterMessages.values()) {
+                    String message = getEventRegisterMessage(filter);
+                    LOG.log(Level.INFO, "Send filter: " + message);
+                    webSocketClient.sendTextFrame(message).get(timeout, TimeUnit.MILLISECONDS);
+                }
+            }
+
         } catch (Throwable ex) {
             closeWs();
 
@@ -208,12 +242,63 @@ public final class DefaultWebSocketClient implements WebSocketClient {
                 LOG.log(Level.FINEST, "connection failed " + this, ex);
             }
 
-            throw new HiroException("connection failed " + this + " " + ex.getMessage() + " " + stacktrace(ex), 400,
-                    ex);
+            throw new HiroException("connection failed " + this + " " + ex.getMessage(), 400, ex);
         }
 
         if (LOG.isLoggable(Level.FINEST)) {
             LOG.log(Level.FINEST, "connection opened " + this);
+        }
+    }
+
+    /**
+     * Reconnect a connection that should not have been closed. This also implements a delay strategy for repeated
+     * attempts to reconnect as suggested per RFC6455. Reconnect attempts only stop on {@link #close()} or an
+     * InterruptedException while sleeping.
+     */
+    private synchronized void reconnect() {
+        Duration nextTryDelay = Duration.ZERO;
+
+        closeWs();
+
+        while (true) {
+            try {
+                if (!running) {
+                    return;
+                }
+
+                long delay = nextTryDelay.getSeconds() * 1000;
+                Thread.sleep(delay);
+
+                if (LOG.isLoggable(Level.INFO)) {
+                    LOG.log(Level.INFO, "Reconnecting " + this);
+                }
+
+                connect(true);
+
+                return;
+            } catch (HiroException ex) {
+
+                LOG.log(Level.SEVERE, "Reconnect caught exception.", ex);
+
+                // Retry strategy
+                if (nextTryDelay.getSeconds() < 3) {
+                    nextTryDelay = nextTryDelay.plusSeconds(1);
+                } else if (nextTryDelay.getSeconds() < 60) {
+                    nextTryDelay = nextTryDelay.plusSeconds(new Random().nextInt(10) + 1);
+                } else {
+                    nextTryDelay = Duration.ofMinutes(new Random().nextInt(10) + 1);
+                }
+
+                if (LOG.isLoggable(Level.INFO)) {
+                    LOG.log(Level.INFO, "Retrying connection after " + nextTryDelay.getSeconds() + "s.");
+                }
+
+            } catch (InterruptedException ex) {
+                closeWs();
+                if (LOG.isLoggable(Level.FINEST)) {
+                    LOG.log(Level.FINEST, "Reconnect interrupted " + this);
+                }
+            }
         }
     }
 
@@ -232,7 +317,7 @@ public final class DefaultWebSocketClient implements WebSocketClient {
         }
 
         if (webSocketClient == null || !webSocketClient.isOpen()) {
-            connect(false, false);
+            reconnect();
         }
 
         if (LOG.isLoggable(Level.FINEST)) {
@@ -247,7 +332,7 @@ public final class DefaultWebSocketClient implements WebSocketClient {
                 LOG.log(Level.WARNING, "send failed, retrying", ex);
 
                 ++retries;
-                connect(true, false);
+                reconnect();
 
                 sendMessage(message);
             } else {
@@ -255,6 +340,62 @@ public final class DefaultWebSocketClient implements WebSocketClient {
                 Throwables.unchecked(ex);
             }
         }
+    }
+
+    @Override
+    public synchronized void addEventFilter(Map filter) {
+        String id = getFilterId(filter);
+        String message = getEventRegisterMessage(filter);
+        LOG.log(Level.INFO, "Add filter: " + message);
+        sendMessage(message);
+        eventFilterMessages.put(id, filter);
+    }
+
+    private String getFilterId(Map filter) {
+        String id = String.valueOf(filter.get("filter-id"));
+        if (id == null || StringUtils.isEmpty(id)) {
+            throw new HiroException("Wrong filter specification. Key 'filter-id' is missing.", 400);
+        }
+        return id;
+    }
+
+    private String getEventRegisterMessage(Map filter) {
+        final Map m = HiroCollections.newMap();
+        m.put("type", "register");
+        m.put("args", filter);
+
+        String message = JSONValue.toJSONString(m);
+
+        return message;
+    }
+
+    @Override
+    public synchronized void removeEventFilter(String id) {
+        final Map m = HiroCollections.newMap();
+        m.put("type", "unregister");
+        m.put("args", HiroCollections.newMap("filter-id", id));
+
+        String message = JSONValue.toJSONString(m);
+
+        LOG.log(Level.INFO, "Remove filter: " + message);
+
+        sendMessage(message);
+        eventFilterMessages.remove(id);
+    }
+
+    @Override
+    public synchronized void clearEventFilters() {
+        final Map m = HiroCollections.newMap();
+        m.put("type", "clear");
+        m.put("args", HiroCollections.newMap());
+
+        String message = JSONValue.toJSONString(m);
+
+        LOG.log(Level.INFO, "Clear filter: " + message);
+
+        sendMessage(message);
+
+        eventFilterMessages.clear();
     }
 
     @Override
@@ -320,20 +461,20 @@ public final class DefaultWebSocketClient implements WebSocketClient {
                 sb.append("/");
 
                 switch (type) {
-                case Event:
-                    sb.append("events-ws/" + DEFAULT_API_VERSION);
-                    break;
+                    case Event:
+                        sb.append("events-ws/" + DEFAULT_API_VERSION);
+                        break;
 
-                case Graph:
-                    sb.append("graph-ws/" + DEFAULT_API_VERSION);
-                    break;
+                    case Graph:
+                        sb.append("graph-ws/" + DEFAULT_API_VERSION);
+                        break;
 
-                case Action:
-                    sb.append("action-ws/" + ACTION_API_VERSION);
-                    break;
+                    case Action:
+                        sb.append("action-ws/" + ACTION_API_VERSION);
+                        break;
 
-                default:
-                    throw new IllegalArgumentException("unknown type " + type);
+                    default:
+                        throw new IllegalArgumentException("unknown type " + type);
                 }
 
                 if (urlParameters != null && !urlParameters.isEmpty()) {
@@ -356,17 +497,17 @@ public final class DefaultWebSocketClient implements WebSocketClient {
 
     private String getProtocol() {
         switch (type) {
-        case Event:
-            return "events-1.0.0";
+            case Event:
+                return "events-1.0.0";
 
-        case Graph:
-            return "graph-2.0.0";
+            case Graph:
+                return "graph-2.0.0";
 
-        case Action:
-            return "action-1.0.0";
+            case Action:
+                return "action-1.0.0";
 
-        default:
-            throw new IllegalArgumentException("unknown type " + type);
+            default:
+                throw new IllegalArgumentException("unknown type " + type);
         }
     }
 
@@ -380,7 +521,7 @@ public final class DefaultWebSocketClient implements WebSocketClient {
                 m.put("message", "ping failed " + t.getMessage());
                 m.put("stack", stacktrace(t));
 
-                process(loglistener, JSONValue.toJSONString(m));
+                process(logListener, JSONValue.toJSONString(m));
             }
         }
     }

--- a/java/hiro-client/src/main/java/co/arago/hiro/client/test/InvalidTimeseriesValue.java
+++ b/java/hiro-client/src/main/java/co/arago/hiro/client/test/InvalidTimeseriesValue.java
@@ -1,10 +1,12 @@
 package co.arago.hiro.client.test;
 
-import static co.arago.hiro.client.api.HiroClient.JSON_TS_VALUE;
 import co.arago.hiro.client.api.TimeseriesValue;
 import co.arago.hiro.client.util.HiroCollections;
-import java.util.Map;
 import net.minidev.json.JSONObject;
+
+import java.util.Map;
+
+import static co.arago.hiro.client.api.HiroClient.JSON_TS_VALUE;
 
 public class InvalidTimeseriesValue implements TimeseriesValue {
 

--- a/java/hiro-client/src/main/java/co/arago/hiro/client/util/DefaultLogValue.java
+++ b/java/hiro-client/src/main/java/co/arago/hiro/client/util/DefaultLogValue.java
@@ -1,8 +1,9 @@
 package co.arago.hiro.client.util;
 
 import co.arago.hiro.client.api.LogValue;
-import java.util.Map;
 import net.minidev.json.JSONObject;
+
+import java.util.Map;
 
 public class DefaultLogValue implements LogValue {
 

--- a/java/hiro-client/src/main/java/co/arago/hiro/client/util/DefaultTimeseriesValue.java
+++ b/java/hiro-client/src/main/java/co/arago/hiro/client/util/DefaultTimeseriesValue.java
@@ -6,10 +6,12 @@
 package co.arago.hiro.client.util;
 
 import co.arago.hiro.client.api.TimeseriesValue;
-import java.util.Map;
 import net.minidev.json.JSONObject;
 
-import static co.arago.hiro.client.api.HiroClient.*;
+import java.util.Map;
+
+import static co.arago.hiro.client.api.HiroClient.JSON_TS_TIMESTAMP;
+import static co.arago.hiro.client.api.HiroClient.JSON_TS_VALUE;
 
 /**
  *

--- a/java/hiro-client/src/main/java/co/arago/hiro/client/util/Helper.java
+++ b/java/hiro-client/src/main/java/co/arago/hiro/client/util/Helper.java
@@ -5,11 +5,12 @@
  */
 package co.arago.hiro.client.util;
 
+import net.minidev.json.JSONValue;
+
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import net.minidev.json.JSONValue;
 
 import static co.arago.hiro.client.api.HiroClient.*;
 

--- a/java/hiro-client/src/main/java/co/arago/hiro/client/util/HiroCollections.java
+++ b/java/hiro-client/src/main/java/co/arago/hiro/client/util/HiroCollections.java
@@ -1,13 +1,6 @@
 package co.arago.hiro.client.util;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 

--- a/java/hiro-client/src/main/java/co/arago/hiro/client/util/HttpClientHelper.java
+++ b/java/hiro-client/src/main/java/co/arago/hiro/client/util/HttpClientHelper.java
@@ -1,15 +1,11 @@
 package co.arago.hiro.client.util;
 
+import org.asynchttpclient.*;
+
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import org.asynchttpclient.AsyncHttpClient;
-import org.asynchttpclient.DefaultAsyncHttpClient;
-import org.asynchttpclient.DefaultAsyncHttpClientConfig;
-import org.asynchttpclient.Param;
-import org.asynchttpclient.Request;
-import org.asynchttpclient.Response;
 
 /**
  *

--- a/java/hiro-client/src/main/java/co/arago/hiro/client/util/SimpleWsListener.java
+++ b/java/hiro-client/src/main/java/co/arago/hiro/client/util/SimpleWsListener.java
@@ -1,10 +1,11 @@
 package co.arago.hiro.client.util;
 
-import java.util.Map;
-import java.util.concurrent.TimeUnit;
 import net.minidev.json.JSONValue;
 import org.asynchttpclient.ws.WebSocket;
 import org.asynchttpclient.ws.WebSocketListener;
+
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 public class SimpleWsListener implements WebSocketListener {
     private final String filter;

--- a/java/hiro-client/src/main/java/co/arago/hiro/client/util/WsUpgradeLogger.java
+++ b/java/hiro-client/src/main/java/co/arago/hiro/client/util/WsUpgradeLogger.java
@@ -1,14 +1,13 @@
 package co.arago.hiro.client.util;
 
+import org.eclipse.jetty.websocket.api.UpgradeRequest;
+import org.eclipse.jetty.websocket.api.UpgradeResponse;
+import org.eclipse.jetty.websocket.client.io.UpgradeListener;
+
 import java.util.List;
 import java.util.Map.Entry;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-
-import co.arago.hiro.client.api.HiroClient;
-import org.eclipse.jetty.websocket.api.UpgradeRequest;
-import org.eclipse.jetty.websocket.api.UpgradeResponse;
-import org.eclipse.jetty.websocket.client.io.UpgradeListener;
 
 /**
  *

--- a/java/hiro-client/src/test/java/co/arago/hiro/client/FakeHiroServer.java
+++ b/java/hiro-client/src/test/java/co/arago/hiro/client/FakeHiroServer.java
@@ -12,19 +12,16 @@ import co.arago.hiro.client.util.HiroException;
 import fi.iki.elonen.NanoHTTPD;
 import fi.iki.elonen.NanoHTTPD.Response.IStatus;
 import fi.iki.elonen.NanoHTTPD.Response.Status;
+import net.minidev.json.JSONValue;
+import org.apache.commons.lang.StringUtils;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import net.minidev.json.JSONValue;
-import org.apache.commons.lang.StringUtils;
 
 import static co.arago.hiro.client.rest.DefaultHiroClient.*;
 

--- a/java/hiro-client/src/test/java/co/arago/hiro/client/FakeRestServer.java
+++ b/java/hiro-client/src/test/java/co/arago/hiro/client/FakeRestServer.java
@@ -7,6 +7,7 @@ package co.arago.hiro.client;
 
 import co.arago.hiro.client.util.Helper;
 import fi.iki.elonen.NanoHTTPD;
+
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;

--- a/java/hiro-client/src/test/java/co/arago/hiro/client/QueryTest.java
+++ b/java/hiro-client/src/test/java/co/arago/hiro/client/QueryTest.java
@@ -7,12 +7,13 @@ package co.arago.hiro.client;
 
 import co.arago.hiro.client.api.HiroClient;
 import co.arago.hiro.client.util.HiroCollections;
-import java.util.HashMap;
-import java.util.List;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 

--- a/java/hiro-client/src/test/java/co/arago/hiro/client/TestHiroClient.java
+++ b/java/hiro-client/src/test/java/co/arago/hiro/client/TestHiroClient.java
@@ -10,25 +10,13 @@ import co.arago.hiro.client.api.TimeseriesValue;
 import co.arago.hiro.client.api.WebSocketClient;
 import co.arago.hiro.client.builder.ClientBuilder;
 import co.arago.hiro.client.builder.TokenBuilder;
-import co.arago.hiro.client.util.DefaultTimeseriesValue;
-import co.arago.hiro.client.util.Helper;
-import co.arago.hiro.client.util.HiroCollections;
-import co.arago.hiro.client.util.HiroException;
-import co.arago.hiro.client.util.Listener;
+import co.arago.hiro.client.util.*;
+import org.junit.*;
+
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.TreeMap;
+import java.util.*;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.logging.Level;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Ignore;
-import org.junit.Test;
 
 import static org.junit.Assert.*;
 

--- a/java/hiro-client/src/test/java/co/arago/hiro/client/TestRest.java
+++ b/java/hiro-client/src/test/java/co/arago/hiro/client/TestRest.java
@@ -5,16 +5,13 @@
 */
 package co.arago.hiro.client;
 
-import co.arago.hiro.client.builder.ClientBuilder;
-import co.arago.hiro.client.builder.TokenBuilder;
 import co.arago.hiro.client.api.RestClient;
 import co.arago.hiro.client.api.TokenProvider;
+import co.arago.hiro.client.builder.ClientBuilder;
+import co.arago.hiro.client.builder.TokenBuilder;
+import org.junit.*;
+
 import java.io.IOException;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
 
 /**
  *

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -5,7 +5,7 @@
   <artifactId>hiro-client-all</artifactId>
   <name>${project.artifactId}</name>
   <packaging>pom</packaging>
-  <version>2.1.4-SNAPSHOT</version>
+  <version>2.1.5-SNAPSHOT</version>
 
   <properties>
     <maven.exec.skip>false</maven.exec.skip>


### PR DESCRIPTION
* Split executeBasicRequest from runBasicRequest. Method runRequest uses
runBasicRequest once and only executeBasicRequest after that first try.
This was the builder gets set up only once and will be reused on all
subsequent tries.

* Debugged autoreconnect after network interruption of websocket.
When handling event-ws, an initial list of filter specifications can be
set. These filters get stored in the DefaultWebSocketClient and will be
set right after the event-ws is connected and will be set again on each
reconnect.